### PR TITLE
refactor: encode cursor and assign it in metadata

### DIFF
--- a/.github/workflows/go-lint-and-test-on-push.yaml
+++ b/.github/workflows/go-lint-and-test-on-push.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: "1.22"
           cache: true
           cache-dependency-path: |
             **/go.sum
@@ -32,12 +32,14 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.55.2
           args: --timeout=5m
+          env:
+            GO111MODULE: on
 
-  # Test job for Go on Linux with Go 1.24
+  # Test job for Go on Linux with Go 1.22
   test:
-    name: Test on Linux with Go 1.24
+    name: Test on Linux with Go 1.22
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: "1.22"
           cache: true
           cache-dependency-path: |
             **/go.sum

--- a/.github/workflows/go-lint-and-test-on-push.yaml
+++ b/.github/workflows/go-lint-and-test-on-push.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: "1.24"
           cache: true
           cache-dependency-path: |
             **/go.sum
@@ -35,9 +35,9 @@ jobs:
           version: v1.54
           args: --timeout=5m
 
-  # Test job for Go on Linux with Go 1.22
+  # Test job for Go on Linux with Go 1.24
   test:
-    name: Test on Linux with Go 1.22
+    name: Test on Linux with Go 1.24
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: "1.24"
           cache: true
           cache-dependency-path: |
             **/go.sum

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # GORM Metakit
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/nccapo/paginate-metakit)](https://goreportcard.com/report/github.com/nccapo/paginate-metakit)
+[![GoDoc](https://godoc.org/github.com/nccapo/paginate-metakit?status.svg)](https://godoc.org/github.com/nccapo/paginate-metakit)
+[![Release](https://img.shields.io/github/v/release/nccapo/paginate-metakit?include_prereleases&sort=semver)](https://github.com/nccapo/paginate-metakit/releases)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/nccapo/paginate-metakit)](https://go.dev/doc/devel/release.html)
+[![License](https://img.shields.io/github/license/nccapo/paginate-metakit)](https://github.com/nccapo/paginate-metakit/blob/main/LICENSE)
+[![Codecov](https://codecov.io/gh/nccapo/paginate-metakit/branch/main/graph/badge.svg)](https://codecov.io/gh/nccapo/paginate-metakit)
+[![GitHub Actions](https://github.com/nccapo/paginate-metakit/actions/workflows/go-lint-and-test-on-push.yaml/badge.svg)](https://github.com/nccapo/paginate-metakit/actions)
+[![GitHub issues](https://img.shields.io/github/issues/nccapo/paginate-metakit)](https://github.com/nccapo/paginate-metakit/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/nccapo/paginate-metakit)](https://github.com/nccapo/paginate-metakit/pulls)
+
 A powerful pagination toolkit for Go applications using GORM and standard SQL databases. This package provides flexible pagination solutions with support for both offset-based and cursor-based pagination.
 
 ## Features

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nccapo/gorm-metakit
 
-go 1.22.2
+go 1.24.2
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.25

--- a/gorm_metakit.go
+++ b/gorm_metakit.go
@@ -3,6 +3,7 @@ package metakit
 import (
 	"encoding/base64"
 	"fmt"
+	"reflect"
 
 	"gorm.io/gorm"
 )
@@ -51,6 +52,18 @@ func Paginate(db *gorm.DB, m *Metadata, result interface{}) error {
 
 	// Update metadata with calculated values
 	m.ValidateAndSetDefaults()
+
+	// Encode cursor for next page if using cursor-based pagination
+	if m.IsCursorBased() && m.HasNext {
+		lastItem := reflect.ValueOf(result).Index(reflect.ValueOf(result).Len() - 1).Interface()
+		cursorData := map[string]interface{}{
+			"id":         reflect.ValueOf(lastItem).FieldByName("ID").Interface(),
+			"created_at": reflect.ValueOf(lastItem).FieldByName("CreatedAt").Interface(),
+			"page":       m.Page,
+		}
+		m.Cursor = encodeCursor(cursorData)
+	}
+
 	return nil
 }
 
@@ -77,6 +90,18 @@ func PaginateWithCount(db *gorm.DB, countQuery *gorm.DB, m *Metadata, result int
 
 	// Update metadata with calculated values
 	m.ValidateAndSetDefaults()
+
+	// Encode cursor for next page if using cursor-based pagination
+	if m.IsCursorBased() && m.HasNext {
+		lastItem := reflect.ValueOf(result).Index(reflect.ValueOf(result).Len() - 1).Interface()
+		cursorData := map[string]interface{}{
+			"id":         reflect.ValueOf(lastItem).FieldByName("ID").Interface(),
+			"created_at": reflect.ValueOf(lastItem).FieldByName("CreatedAt").Interface(),
+			"page":       m.Page,
+		}
+		m.Cursor = encodeCursor(cursorData)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### **What's new in this updated version?**
- Removed the duplicate GPaginate function
- Added cursor encoding to both Paginate and PaginateWithCount functions
- Kept the original scope-based GPaginate function
- The code is now cleaner and properly uses the encodeCursor function in both pagination methods. The linter error about unused encodeCursor should be resolved since we're now using it in both pagination functions.