### PR TITLE
refactor: fix query pagination and param arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,3 +450,35 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
+
+### SQL Pagination
+
+```go
+// Using standard SQL pagination
+metadata := metakit.NewMetadata().
+    WithPage(1).
+    WithPageSize(10).
+    WithSort("created_at").
+    WithSortDirection("desc")
+
+// Method 1: Using the metadata object
+rows, err := metakit.QueryContextPaginate(ctx, db, metakit.PostgreSQL, "SELECT * FROM users", metadata)
+
+// Method 2: Passing sort field and direction as separate arguments
+rows, err := metakit.QueryContextPaginate(ctx, db, metakit.PostgreSQL, "SELECT * FROM users", metadata, "id", "asc")
+
+// Method 3: Using with PostgreSQL parameters
+query := "SELECT * FROM users WHERE created_at > $1"
+createdAt := time.Now().Add(-24 * time.Hour)
+rows, err := metakit.QueryContextPaginate(ctx, db, metakit.PostgreSQL, query, metadata, createdAt)
+```
+
+### Validation
+
+```go
+// Validate metadata
+result := metadata.Validate()
+if !result.IsValid {
+    // Handle validation errors
+}
+```


### PR DESCRIPTION
### **What's new in this updated version?**

- Updated the `QueryContextPaginate` function to properly handle PostgreSQL-style parameters ($1, $2, etc.). The function now counts the existing parameters in the query and uses the correct parameter numbers for the LIMIT and OFFSET clauses.
- Updated the `applyCursorSQLPagination` function to handle PostgreSQL parameters correctly as well, ensuring consistency across both pagination methods.
- Added a test to verify that the function works correctly with PostgreSQL-style parameters.
- Updated the `README` to document this feature, showing how to use the function with PostgreSQL parameters.